### PR TITLE
Fix for issue #4

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -28,7 +28,12 @@ async function fetchWithRetries(
   if (res.status === 429 && max_retries > 0) {
     const rateLimitReset = Number(res.headers.get("x-rate-limit-reset"));
     const timeTillReset = rateLimitReset * 1000 - Date.now();
-    await new Promise((resolve) => setTimeout(resolve, timeTillReset));
+    let timeToWait = 0;
+    if (rateLimitRemaining == 0)
+      timeToWait = timeTillReset;
+    else
+      timeToWait = 1000;
+    await new Promise((resolve) => setTimeout(resolve, timeToWait));
     return fetchWithRetries(url, init, max_retries - 1);
   }
   return res;

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,6 +27,7 @@ async function fetchWithRetries(
   const res = await fetch(url, init);
   if (res.status === 429 && max_retries > 0) {
     const rateLimitReset = Number(res.headers.get("x-rate-limit-reset"));
+    const rateLimitRemaining = Number(res.headers.get("x-rate-limit-remaining"));
     const timeTillReset = rateLimitReset * 1000 - Date.now();
     let timeToWait = 0;
     if (rateLimitRemaining == 0)

--- a/src/request.ts
+++ b/src/request.ts
@@ -29,11 +29,9 @@ async function fetchWithRetries(
     const rateLimitReset = Number(res.headers.get("x-rate-limit-reset"));
     const rateLimitRemaining = Number(res.headers.get("x-rate-limit-remaining"));
     const timeTillReset = rateLimitReset * 1000 - Date.now();
-    let timeToWait = 0;
-    if (rateLimitRemaining == 0)
+    let timeToWait = 1000;
+    if (rateLimitRemaining === 0)
       timeToWait = timeTillReset;
-    else
-      timeToWait = 1000;
     await new Promise((resolve) => setTimeout(resolve, timeToWait));
     return fetchWithRetries(url, init, max_retries - 1);
   }


### PR DESCRIPTION
### Problem

The api call `tweetsFullarchiveSearch` in Academic Access has an extra rate limit of 1 tpsec, that is fired in each pagination call. The `fetchWithRetries` is not aware of the secondary rate limit of 1 tpsec, setting a timeout referred to the reset window of the api call (15 min), making the library to add an excessive delay each pagination request is done.

### Solution

Now, the `fetchWithRetries` checks if the rate limit hit is the right one by examining the `x-rate-limit-remaining` header and checking if it is zero (300 calls / 15 min). Depending on the value, it throttles the call 1 sec or the remaining time to the reset the time window.

### Result

The library performs as expected independently of the rate limit hit.
