### PR TITLE
remove dry_run from filtered stream example

### DIFF
--- a/examples/filtered-stream.ts
+++ b/examples/filtered-stream.ts
@@ -16,9 +16,6 @@ async function main() {
         { value: "meme", tag: "funny things" },
         { value: "meme has:images" },
       ],
-    },
-    {
-      dry_run: true,
     }
   );
   const rules = await client.tweets.getRules();


### PR DESCRIPTION
### Problem

It is confusing having `dry_run: true` in the example code, because the stream doesn't work without rules

### Solution

Remove `dry_run: true`