### PR TITLE
8 access token access

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A TypeScript SDK for the Twitter API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/OAuth2User.ts
+++ b/src/OAuth2User.ts
@@ -78,19 +78,19 @@ interface RevokeAccessTokenResponse {
 }
 
 interface GetTokenResponse {
+  /** Allows an application to obtain a new access token without prompting the user via the refresh token flow. */
   refresh_token?: string;
+  /** Access tokens are the token that applications use to make API requests on behalf of a user.  */
   access_token?: string;
   token_type?: string;
   expires_in?: number;
+  /** Comma-separated list of scopes for the token  */
   scope?: string;
 }
 
-interface Token {
-  refresh_token?: string;
-  access_token?: string;
-  token_type?: string;
+interface Token extends Omit<GetTokenResponse, 'expires_in'> {
+  /** Date that the access_token will expire at.  */
   expires_at?: Date;
-  scope?: string;
 }
 
 function processTokenResponse(token: GetTokenResponse): Token {

--- a/src/request.ts
+++ b/src/request.ts
@@ -60,7 +60,7 @@ export async function request({
     url.toString(),
     {
       headers: {
-        "User-Agent": `twitter-api-typescript-sdk/1.0.4`,
+        "User-Agent": `twitter-api-typescript-sdk/1.0.5`,
         ...(isPost
           ? { "Content-Type": "application/json; charset=utf-8" }
           : undefined),


### PR DESCRIPTION
### Problem

User can't get the `access_token` from the client, and it is easier if the `requestAccessToken` and `refreshAccessToken` return the token

### Solution

Allowed the user to get the `access_token` from the client and returned the token from `requestAccessToken` and `refreshAccessToken` methods