### PR TITLE
export type Token to be able to pass back into constructor

### DIFF
--- a/src/OAuth2User.ts
+++ b/src/OAuth2User.ts
@@ -90,7 +90,7 @@ interface GetTokenResponse {
   scope?: string;
 }
 
-interface Token extends Omit<GetTokenResponse, "expires_in"> {
+export interface Token extends Omit<GetTokenResponse, "expires_in"> {
   /** Date that the access_token will expire at.  */
   expires_at?: number;
 }


### PR DESCRIPTION
be able to use type Token in order to utilize the latest commit about adding "token" to the constructor