### PR TITLE
Add verified_type field to User schema

### DIFF
--- a/src/gen/openapi-types.ts
+++ b/src/gen/openapi-types.ts
@@ -1895,6 +1895,8 @@ export interface components {
       username: components["schemas"]["UserName"];
       /** @description Indicate if this User is a verified Twitter User. */
       verified?: boolean;
+      /** @description Indicates the type of verification for the Twitter account. */
+      verified_type?: "blue" | "business" | "government" | "none";
       withheld?: components["schemas"]["UserWithheld"];
     };
     /** @description User compliance data. */

--- a/src/gen/openapi-types.ts
+++ b/src/gen/openapi-types.ts
@@ -2331,6 +2331,7 @@ export interface components {
       | "url"
       | "username"
       | "verified"
+      | "verified_type"
       | "withheld"
     )[];
   };


### PR DESCRIPTION
This commit adds a new field to the User schema that indicates the type of verification for the Twitter account. The field can take one of four values: blue, business, government, or none. To retrieve the verified_type field in API requests, users should include the user.fields=verified_type parameter in the query string.

### Problem

The Twitter API's user schema currently does not include a field that indicates the type of verification for a Twitter account. This can make it difficult for developers to build applications that rely on verified account data.

### Solution

This commit adds a new field to the User schema called `verified_type` that indicates the type of verification for a Twitter account. The `verified_type` field can take one of four possible values: "blue", "business", "government", or "none". To retrieve the `verified_type` field in API requests, users should include the `user.fields=verified_type` parameter in the query string.

### Result

As a result of this pull request, developers will have access to more granular information about the type of verification applied to a Twitter account. This can improve the usability of the Twitter API and enable developers to build more advanced applications that rely on verified account data.
