### PR TITLE
auth: Use webcrypto & Uint8Array instead of NodeJS crypto & Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const client = new Client(authClient);
 ### Generating an Authentication URL
 
 ```typescript
-const authUrl = authClient.generateAuthURL({
+const authUrl = await authClient.generateAuthURL({
   code_challenge_method: "s256",
 });
 ```

--- a/examples/oauth2-callback.ts
+++ b/examples/oauth2-callback.ts
@@ -32,7 +32,7 @@ app.get("/callback", async function (req, res) {
 });
 
 app.get("/login", async function (req, res) {
-  const authUrl = authClient.generateAuthURL({
+  const authUrl = await authClient.generateAuthURL({
     state: STATE,
     code_challenge_method: "s256",
   });

--- a/examples/oauth2-callback_pkce_plain.ts
+++ b/examples/oauth2-callback_pkce_plain.ts
@@ -32,7 +32,7 @@ app.get("/callback", async function (req, res) {
 });
 
 app.get("/login", async function (req, res) {
-  const authUrl = authClient.generateAuthURL({
+  const authUrl = await authClient.generateAuthURL({
     state: STATE,
     code_challenge_method: "plain",
     code_challenge: "test",

--- a/examples/oauth2-callback_pkce_s256.ts
+++ b/examples/oauth2-callback_pkce_s256.ts
@@ -32,7 +32,7 @@ app.get("/callback", async function (req, res) {
 });
 
 app.get("/login", async function (req, res) {
-  const authUrl = authClient.generateAuthURL({
+  const authUrl = await authClient.generateAuthURL({
     state: STATE,
     code_challenge_method: "s256",
   });

--- a/examples/oauth2-public-callback_pkce_s256.ts
+++ b/examples/oauth2-public-callback_pkce_s256.ts
@@ -31,7 +31,7 @@ app.get("/callback", async function (req, res) {
 });
 
 app.get("/login", async function (req, res) {
-  const authUrl = authClient.generateAuthURL({
+  const authUrl = await authClient.generateAuthURL({
     state: STATE,
     code_challenge_method: "s256",
   });

--- a/src/OAuth2User.ts
+++ b/src/OAuth2User.ts
@@ -242,7 +242,7 @@ export class OAuth2User implements AuthClient {
     });
   }
 
-  generateAuthURL(options: GenerateAuthUrlOptions): string {
+  async generateAuthURL(options: GenerateAuthUrlOptions): Promise<string> {
     const { client_id, callback, scopes } = this.#options;
     if (!callback) throw new Error("callback required");
     if (!scopes) throw new Error("scopes required");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,8 +12,10 @@ export function buildQueryString(query: Record<string, any>): string {
     .join("&");
 }
 
+export function base64Encode(byteValues: Uint8Array): string {
+  return btoa([...byteValues].map(byteValue => String.fromCharCode(byteValue)).join(''))
+}
+
 export function basicAuthHeader(client_id: string, client_secret: string) {
-  return `Basic ${Buffer.from(`${client_id}:${client_secret}`).toString(
-    "base64"
-  )}`;
+  return `Basic ${base64Encode(new TextEncoder().encode(`${client_id}:${client_secret}`))}`
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,15 @@
+// Copyright 2021 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { base64Encode } from "../src/utils";
+
+describe("test utils", () => {
+
+  test("base64Encode is equivalent to Buffer.toString('base64')", () => {
+    for (let i = 0; i < 64; i++) { // go through all 64 symbols
+      const byteValues = new Uint8Array([i << 2]);
+      expect(base64Encode(byteValues)).toEqual(Buffer.from(Buffer.from(byteValues)).toString("base64"));
+    }
+  });
+
+});


### PR DESCRIPTION
### Problem

The current `auth` implementation makes use of NodeJS `crypto` package and `Buffer`, and because of this the library cannot be used in contexts where these are unavailable, such as [on Cloudflare workers](https://developers.cloudflare.com/workers/runtime-apis/web-crypto).

### Solution

The solution was to replace NodeJS primitives with their standard counterparts.

### Result

As a result of the changes in this PR, it will be possible to use the library on environments where NodeJS `crypto` and `Buffer` are not available, such as Cloudflare workers.